### PR TITLE
Font: Display → Text (style)

### DIFF
--- a/Builds/fluent-theme/Dark.qss
+++ b/Builds/fluent-theme/Dark.qss
@@ -268,7 +268,7 @@ QTreeView::branch:has-children:open:hover {
 
 /*HEADERVIEW*/
 QHeaderView {
-    font-family: "Segoe UI Variable Text";
+    font-family: "Segoe UI Variable Small";
     font-size: 12px;
     background-color: transparent; 
     text-align: center;

--- a/Builds/fluent-theme/Dark.qss
+++ b/Builds/fluent-theme/Dark.qss
@@ -5,7 +5,7 @@ QDockWidget {
 }
 
 QWidget {
-    font-family: "Segoe UI Variable Display";
+    font-family: "Segoe UI Variable Text";
     font-size: 13px;
     border-radius: 5px;
     border-color: rgb(255, 255, 255, 8);
@@ -268,7 +268,7 @@ QTreeView::branch:has-children:open:hover {
 
 /*HEADERVIEW*/
 QHeaderView {
-    font-family: "Segoe UI Variable Display";
+    font-family: "Segoe UI Variable Text";
     font-size: 12px;
     background-color: transparent; 
     text-align: center;

--- a/Builds/fluent-theme/Light.qss
+++ b/Builds/fluent-theme/Light.qss
@@ -268,7 +268,7 @@ QTreeView::branch:has-children:open:hover {
 
 /*HEADERVIEW*/
 QHeaderView {
-    font-family: "Segoe UI Variable Text";
+    font-family: "Segoe UI Variable Small";
     font-size: 12px;
     background-color: transparent; 
     text-align: center;

--- a/Builds/fluent-theme/Light.qss
+++ b/Builds/fluent-theme/Light.qss
@@ -5,7 +5,7 @@ QDockWidget {
 }
 
 QWidget {
-    font-family: "Segoe UI Variable Display";
+    font-family: "Segoe UI Variable Text";
     font-size: 13px;
     border-radius: 5px;
     border-color: rgb(0, 0, 0, 8);
@@ -268,7 +268,7 @@ QTreeView::branch:has-children:open:hover {
 
 /*HEADERVIEW*/
 QHeaderView {
-    font-family: "Segoe UI Variable Display";
+    font-family: "Segoe UI Variable Text";
     font-size: 12px;
     background-color: transparent; 
     text-align: center;


### PR DESCRIPTION
You have selected the Display variant, which as the name says it’s intended for large sizes. You should replace Segoe UI Variable Display with Text style. Otherwise, the fonts look worse.

Explanation:
![image](https://user-images.githubusercontent.com/13555921/173170394-c3a55f53-dbeb-48af-a56a-6600a4696d34.png)
https://docs.microsoft.com/en-us/windows/apps/design/signature-experiences/typography#type-ramp